### PR TITLE
Increase rating efficiency

### DIFF
--- a/leaderboard/rankings.py
+++ b/leaderboard/rankings.py
@@ -1,3 +1,5 @@
+import leaderboard.models
+
 DEFAULT_ELO_RATING = 1000
 DEFAULT_K_FACTOR = 30
 
@@ -5,8 +7,12 @@ DEFAULT_K_FACTOR = 30
 class EloRating(object):
     """Uses Elo rating system to rate players."""
 
-    def __init__(self):
+    def __init__(self, use_current_ratings=False):
         self.ratings = {}
+        if use_current_ratings:
+            rated_players = leaderboard.models.PlayerRating.objects.all()
+            for rated_player in rated_players:
+                self.ratings[rated_player.player] = rated_player.rating
         
     def get_rating(self, player):
         """Return the rating of the specified player."""

--- a/leaderboard/tests/test_models.py
+++ b/leaderboard/tests/test_models.py
@@ -238,6 +238,7 @@ class PlayerRatingTest(TestCase):
             losing_score=19,
             datetime=pytz.utc.localize(datetime(2000, 1, 1))
         )
+        PlayerRating.generate_ratings()
         ranking1 = PlayerRating.objects.get(pk=self.player1.id)
         ranking2 = PlayerRating.objects.get(pk=self.player2.id)
         self.assertGreater(ranking2.rating, ranking1.rating)

--- a/leaderboard/tests/test_rankings.py
+++ b/leaderboard/tests/test_rankings.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from leaderboard.rankings import EloRating, DEFAULT_ELO_RATING, DEFAULT_K_FACTOR
+from leaderboard.models import PlayerRating, Player
 
 
 class EloRatingTest(TestCase):
@@ -69,3 +70,11 @@ class EloRatingTest(TestCase):
         expected_loser_rating = DEFAULT_ELO_RATING - DEFAULT_K_FACTOR * 0.5
         self.assertEqual(winner_rating, expected_winner_rating)
         self.assertEqual(loser_rating, expected_loser_rating)
+
+    def test_use_current_rating(self):
+        """Test that the EloRating class can use current ratings."""
+        player = Player.objects.create(first_name='Bob', last_name='Hope')
+        test_rating = 1013
+        rated_player = PlayerRating.objects.create(player=player, rating=test_rating)
+        rating = EloRating(use_current_ratings=True)
+        self.assertEqual(test_rating, rating.get_rating(player))


### PR DESCRIPTION
Greatly increase rating speed by only regenerating all ratings upon updating an existing match. When new matches are added, it simply updates ratings for the two players involved based on previous ratings.